### PR TITLE
chore: set minimum next.js version to 13.1.0

### DIFF
--- a/packages/next-public-ts/package.json
+++ b/packages/next-public-ts/package.json
@@ -34,6 +34,6 @@
     "public"
   ],
   "peerDependencies": {
-    "next": "^13.5.0 || ^14.0.0"
+    "next": "^13.1.0 || ^14.0.0"
   }
 }


### PR DESCRIPTION
Because https://github.com/vercel/next.js/blob/efcec4c1e303848a5293cef6961be8f73fd5160b/packages/next/src/build/swc/index.ts includes all functions we need and this file is available in next@13.1.0