### PR TITLE
fix: Doesn't support `turbo`

### DIFF
--- a/examples/auto-detect/next.config.js
+++ b/examples/auto-detect/next.config.js
@@ -13,7 +13,8 @@ const nextConfig = {
       enabled: !context.isServer && !context.dev,
     }));
     return config;
-  }
+  },
+  turbopack: {},
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Closes #70

Patch generated by `qwen3.6-35b-a3b via local API`.